### PR TITLE
Fix circular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omegadot/einheiten",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/cjs/index.js",
   "module": "dist/es6/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/quantities/definitions.ts
+++ b/src/quantities/definitions.ts
@@ -1,7 +1,6 @@
 import { Qty } from "../index";
 import QtyError from "./error";
 import { IRegularObject, IScalarAndUnit, UnitDefinition } from "./types";
-import { isNumber } from "./utils";
 
 export const UNITS: IRegularObject<UnitDefinition> = {
 	/* prefixes */
@@ -572,7 +571,7 @@ export const UNITY_ARRAY = [UNITY];
  */
 function validateUnitDefinition(unitDef: string, definition: UnitDefinition) {
 	const [, scalar, , numerator = [], denominator = []] = definition;
-	if (!isNumber(scalar)) {
+	if (!Number.isFinite(scalar)) {
 		throw new QtyError(`${unitDef}: Invalid unit definition. ` + `'scalar' must be a number`);
 	}
 


### PR DESCRIPTION
In definitions.ts, call `Number.isFinite` instead of `isNumber` from utils.ts to avoid a circular dependency.